### PR TITLE
modifies from_pretrained to accept revision argument

### DIFF
--- a/OnT.py
+++ b/OnT.py
@@ -202,7 +202,7 @@ class OntologyTransformer(nn.Module):
         return output_path
     
     @staticmethod
-    def from_pretrained(input_path: str):
+    def from_pretrained(input_path: str, revision: str | None = None):
         """Load the model with all its attributes.
         
         Args:
@@ -212,7 +212,7 @@ class OntologyTransformer(nn.Module):
             Loaded OntologyTransformer model
         """
         # Load base HierarchyTransformer model
-        base_model = HierarchyTransformer.from_pretrained(input_path)
+        base_model = HierarchyTransformer.from_pretrained(input_path, revision=revision)
         
         # Load wrapper configuration
         import json


### PR DESCRIPTION
## Issue Description

Instructions on HF for loading different model revisions specify that the static method `from_pretrained` (within the `OntologyTransformer` class, see [OnT.py](https://github.com/HuiYang1997/OnT/blob/main/OnT.py#L205)) accepts a `revision` parameter, specifically:

```python
from OnT import OntologyTransformer

# Default version (main branch - OnTr with role embedding)
ont = OntologyTransformer.from_pretrained("Hui97/OnT-MiniLM-L12-galen")

# Role-free version (without role embedding)
ont = OntologyTransformer.from_pretrained("Hui97/OnT-MiniLM-L12-galen", revision="role-free")

# Inference version with role embedding
ont = OntologyTransformer.from_pretrained("Hui97/OnT-MiniLM-L12-galen", revision="inference-default")

# Inference version without role embedding
ont = OntologyTransformer.from_pretrained("Hui97/OnT-MiniLM-L12-galen", revision="inference-role-free")
```

However, the method is not parameterised in this manner, leading to an exception when a user follows the documented steps for loading an alternative model revision.

## Changes

The included changes in this PR partially satisfy the method contract for `from_pretrained` by adding the neccesary revision parameter, then passing it through to the HiT model when its `from_pretrained` method is subsequently called.

Note that `revision` [is described as](https://github.com/huggingface/sentence-transformers/blob/main/sentence_transformers/SentenceTransformer.py#L86):

	revision (str, optional): The specific model version to use. It can be a branch name, a tag name, or a commit id, for a stored model on Hugging Face.

No other changes have been made.

## Additional Notes

**Note that this PR has been opened simply to log the issue and provide a potential solution. Please review any potential implications that I may not be aware of prior to merging.**